### PR TITLE
fix: correct links to CONTRIBUTING.md in documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,7 +23,7 @@ A complete list of code contributors is available via [GitHub’s contributors g
 
 ## How to Become a Contributor
 
-See our [CONTRIBUTING.md](../CONTRIBUTING.md.md) for details on how to:
+See our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to:
 
 * Report issues
 * Propose features

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Out of scope:
 TwigBush follows an **open governance** model:
 
 * Decisions are made in public via GitHub issues and discussions
-* Maintainers are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md.md)
+* Maintainers are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md)
 * New maintainers are nominated and approved by existing maintainers through documented consensus
 * Community involvement from implementers, operators, and researchers is strongly encouraged
 
@@ -159,8 +159,8 @@ TwigBush aligns with CNCF Sandbox goals:
 TwigBush is at a **proof-of-concept stage**. Breaking changes should be expected.
 We welcome feedback, issue reports, and contributions.
 
-* See [CONTRIBUTING.md](CONTRIBUTING.md.md) for guidelines
-* Maintainers and contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md.md)
+* See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
+* Maintainers and contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md)
 
 ---
 


### PR DESCRIPTION
Fix broken links in README.md and CONTRIBUTORS.md by removing erroneous `.md.md` references and correctly linking to CONTRIBUTORS.md and CONTRIBUTING.md, improving navigation for new contributors.